### PR TITLE
Add WhatsApp notification integration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,20 +1,31 @@
 # @shopify/shopify-app-template-remix
 
+## 2025.07.12
+
+- Add WhatsApp notification integration for order creation and fulfillment events
+
 ## 2025.07.07
+
 - [#1103](https://github.com/Shopify/shopify-app-template-remix/pull/1086) Remove deprecated .npmrc config values
 
 ## 2025.06.12
+
 - [#1075](https://github.com/Shopify/shopify-app-template-remix/pull/1075) Add Shopify MCP to [VSCode configs](https://code.visualstudio.com/docs/copilot/chat/mcp-servers#_enable-mcp-support-in-vs-code)
 
 ## 2025.06.12
+
 -[#1082](https://github.com/Shopify/shopify-app-template-remix/pull/1082) Remove local Shopify CLI from the template. Developers should use the Shopify CLI [installed globally](https://shopify.dev/docs/api/shopify-cli#installation).
+
 ## 2025.03.18
+
 -[#998](https://github.com/Shopify/shopify-app-template-remix/pull/998) Update to Vite 6
 
 ## 2025.03.01
+
 - [#982](https://github.com/Shopify/shopify-app-template-remix/pull/982) Add Shopify Dev Assistant extension to the VSCode extension recommendations
 
 ## 2025.01.31
+
 - [#952](https://github.com/Shopify/shopify-app-template-remix/pull/952) Update to Shopify App API v2025-01
 
 ## 2025.01.23
@@ -29,9 +40,11 @@
 
 - [#904](https://github.com/Shopify/shopify-app-template-remix/pull/904) bump `@shopify/app-bridge-react` to latest
 -
+
 ## 2024.12.18
 
 - [875](https://github.com/Shopify/shopify-app-template-remix/pull/875) Add Scopes Update Webhook
+
 ## 2024.12.05
 
 - [#910](https://github.com/Shopify/shopify-app-template-remix/pull/910) Install `openssl` in Docker image to fix Prisma (see [#25817](https://github.com/prisma/prisma/issues/25817#issuecomment-2538544254))
@@ -44,6 +57,7 @@
 - [#891](https://github.com/Shopify/shopify-app-template-remix/pull/891) Enable remix future flags.
 
 ## 2024.11.26
+
 - [888](https://github.com/Shopify/shopify-app-template-remix/pull/888) Update restResources version to 2024-10
 
 ## 2024.11.06

--- a/README.md
+++ b/README.md
@@ -110,8 +110,8 @@ The database that works best for you depends on the data your app needs and how 
 You can run your database of choice on a server yourself or host it with a SaaS company.
 Here's a short list of databases providers that provide a free tier to get started:
 
-| Database   | Type             | Hosters                                                                                                                                                                                                                               |
-| ---------- | ---------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Database   | Type             | Hosters                                                                                                                                                                                                                                    |
+| ---------- | ---------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
 | MySQL      | SQL              | [Digital Ocean](https://www.digitalocean.com/products/managed-databases-mysql), [Planet Scale](https://planetscale.com/), [Amazon Aurora](https://aws.amazon.com/rds/aurora/), [Google Cloud SQL](https://cloud.google.com/sql/docs/mysql) |
 | PostgreSQL | SQL              | [Digital Ocean](https://www.digitalocean.com/products/managed-databases-postgresql), [Amazon Aurora](https://aws.amazon.com/rds/aurora/), [Google Cloud SQL](https://cloud.google.com/sql/docs/postgres)                                   |
 | Redis      | Key-value        | [Digital Ocean](https://www.digitalocean.com/products/managed-databases-redis), [Amazon MemoryDB](https://aws.amazon.com/memorydb/)                                                                                                        |
@@ -201,7 +201,7 @@ Shopify apps are best when they are embedded in the Shopify Admin, which is how 
 2. Pass `isEmbeddedApp: false` to `shopifyApp()` in `./app/shopify.server.js|ts`.
 3. Change the `isEmbeddedApp` prop to `isEmbeddedApp={false}` for the `AppProvider` in `/app/routes/app.jsx|tsx`.
 4. Remove the `@shopify/app-bridge-react` dependency from [package.json](./package.json) and `vite.config.ts|js`.
-5. Remove anything imported from `@shopify/app-bridge-react`.  For example: `NavMenu`, `TitleBar` and `useAppBridge`.
+5. Remove anything imported from `@shopify/app-bridge-react`. For example: `NavMenu`, `TitleBar` and `useAppBridge`.
 
 ### OAuth goes into a loop when I change my app's scopes
 
@@ -228,9 +228,9 @@ pnpm run deploy
 
 ### My shop-specific webhook subscriptions aren't updated
 
-If you are registering webhooks in the `afterAuth` hook, using `shopify.registerWebhooks`, you may find that your subscriptions aren't being updated.  
+If you are registering webhooks in the `afterAuth` hook, using `shopify.registerWebhooks`, you may find that your subscriptions aren't being updated.
 
-Instead of using the `afterAuth` hook, the recommended approach is to declare app-specific webhooks in the `shopify.app.toml` file.  This approach is easier since Shopify will automatically update changes to webhook subscriptions every time you run `deploy` (e.g: `npm run deploy`).  Please read these guides to understand more:
+Instead of using the `afterAuth` hook, the recommended approach is to declare app-specific webhooks in the `shopify.app.toml` file. This approach is easier since Shopify will automatically update changes to webhook subscriptions every time you run `deploy` (e.g: `npm run deploy`). Please read these guides to understand more:
 
 1. [app-specific vs shop-specific webhooks](https://shopify.dev/docs/apps/build/webhooks/subscribe#app-specific-subscriptions)
 2. [Create a subscription tutorial](https://shopify.dev/docs/apps/build/webhooks/subscribe/get-started?framework=remix&deliveryMethod=https)
@@ -244,7 +244,7 @@ During normal development, the app won't need to re-authenticate most of the tim
 
 ### Admin created webhook failing HMAC validation
 
-Webhooks subscriptions created in the [Shopify admin](https://help.shopify.com/en/manual/orders/notifications/webhooks) will fail HMAC validation. This is because the webhook payload is not signed with your app's secret key.  There are 2 solutions:
+Webhooks subscriptions created in the [Shopify admin](https://help.shopify.com/en/manual/orders/notifications/webhooks) will fail HMAC validation. This is because the webhook payload is not signed with your app's secret key. There are 2 solutions:
 
 1. Use [app-specific webhooks](https://shopify.dev/docs/apps/build/webhooks/subscribe#app-specific-subscriptions) defined in your toml file instead (recommended)
 2. Create [webhook subscriptions](https://shopify.dev/docs/api/shopify-app-remix/v1/guide-webhooks) using the `shopifyApp` object.
@@ -330,7 +330,7 @@ You don't have to make any changes to the code in order to be able to upgrade Po
 ### "nbf" claim timestamp check failed
 
 This error will occur of the `nbf` claim timestamp check failed. This is because the JWT token is expired.
-If you  are consistently getting this error, it could be that the clock on your machine is not in sync with the server.
+If you are consistently getting this error, it could be that the clock on your machine is not in sync with the server.
 
 To fix this ensure you have enabled `Set time and date automatically` in the `Date and Time` settings on your computer.
 
@@ -368,4 +368,10 @@ This template uses [Remix](https://remix.run). The following Shopify tools are a
 - [Shopify CLI](https://shopify.dev/docs/apps/tools/cli)
 - [App extensions](https://shopify.dev/docs/apps/app-extensions/list)
 - [Shopify Functions](https://shopify.dev/docs/api/functions)
+-
+
+## WhatsApp Notifications
+
+The app can notify customers about order creation and fulfillment using the Meta WhatsApp Cloud API. Configure your WhatsApp credentials and template names on the **WhatsApp** page inside the app.
+
 - [Getting started with internationalizing your app](https://shopify.dev/docs/apps/best-practices/internationalization/getting-started)

--- a/app/models.whatsapp.server.js
+++ b/app/models.whatsapp.server.js
@@ -1,0 +1,13 @@
+import prisma from "../db.server";
+
+export async function getWhatsappConfig(shop) {
+  return prisma.whatsappConfig.findUnique({ where: { shop } });
+}
+
+export async function saveWhatsappConfig(shop, data) {
+  return prisma.whatsappConfig.upsert({
+    where: { shop },
+    create: { shop, ...data },
+    update: data,
+  });
+}

--- a/app/routes/app.jsx
+++ b/app/routes/app.jsx
@@ -23,6 +23,7 @@ export default function App() {
           Home
         </Link>
         <Link to="/app/additional">Additional page</Link>
+        <Link to="/app/whatsapp">WhatsApp</Link>
       </NavMenu>
       <Outlet />
     </AppProvider>

--- a/app/routes/app.whatsapp.jsx
+++ b/app/routes/app.whatsapp.jsx
@@ -1,0 +1,90 @@
+import { Form, useLoaderData } from "@remix-run/react";
+import {
+  Page,
+  Layout,
+  Card,
+  TextField,
+  Button,
+  BlockStack,
+  InlineStack,
+  Checkbox,
+} from "@shopify/polaris";
+import { TitleBar } from "@shopify/app-bridge-react";
+import { authenticate } from "../shopify.server";
+import {
+  getWhatsappConfig,
+  saveWhatsappConfig,
+} from "../models.whatsapp.server";
+
+export const loader = async ({ request }) => {
+  const { admin, session } = await authenticate.admin(request);
+  const config = await getWhatsappConfig(session.shop);
+  return { config };
+};
+
+export const action = async ({ request }) => {
+  const { session } = await authenticate.admin(request);
+  const form = await request.formData();
+  const data = {
+    accessToken: form.get("accessToken") || "",
+    phoneNumberId: form.get("phoneNumberId") || "",
+    orderTemplate: form.get("orderTemplate") || null,
+    fulfillTemplate: form.get("fulfillTemplate") || null,
+    status: form.get("status") === "on",
+  };
+  await saveWhatsappConfig(session.shop, data);
+  return null;
+};
+
+export default function WhatsappSettings() {
+  const { config } = useLoaderData();
+  return (
+    <Page>
+      <TitleBar title="WhatsApp Settings" />
+      <Layout>
+        <Layout.Section>
+          <Card>
+            <Form method="post">
+              <BlockStack gap="300">
+                <TextField
+                  name="phoneNumberId"
+                  label="Phone Number ID"
+                  defaultValue={config?.phoneNumberId || ""}
+                  autoComplete="off"
+                />
+                <TextField
+                  name="accessToken"
+                  label="Access Token"
+                  defaultValue={config?.accessToken || ""}
+                  autoComplete="off"
+                />
+                <TextField
+                  name="orderTemplate"
+                  label="Order Template Name"
+                  defaultValue={config?.orderTemplate || ""}
+                  autoComplete="off"
+                />
+                <TextField
+                  name="fulfillTemplate"
+                  label="Fulfillment Template Name"
+                  defaultValue={config?.fulfillTemplate || ""}
+                  autoComplete="off"
+                />
+                <Checkbox
+                  name="status"
+                  label="Enable notifications"
+                  defaultChecked={config?.status ?? true}
+                />
+                <InlineStack>
+                  <Button submit primary>
+                    Save
+                  </Button>
+                </InlineStack>
+              </BlockStack>
+            </Form>
+          </Card>
+        </Layout.Section>
+      </Layout>
+    </Page>
+  );
+}

--- a/app/routes/webhooks.fulfillments.create.jsx
+++ b/app/routes/webhooks.fulfillments.create.jsx
@@ -1,0 +1,27 @@
+import { authenticate } from "../shopify.server";
+import { getWhatsappConfig } from "../models.whatsapp.server";
+import { sendWhatsappTemplate } from "../whatsapp.server";
+
+export const action = async ({ request }) => {
+  const { payload, shop, topic } = await authenticate.webhook(request);
+  console.log(`Received ${topic} webhook for ${shop}`);
+
+  const config = await getWhatsappConfig(shop);
+  if (!config || !config.status || !config.fulfillTemplate) {
+    return new Response();
+  }
+  const phone =
+    payload?.order?.customer?.phone ||
+    payload?.order?.shipping_address?.phone ||
+    payload?.order?.billing_address?.phone;
+
+  if (phone) {
+    await sendWhatsappTemplate({
+      phoneNumberId: config.phoneNumberId,
+      accessToken: config.accessToken,
+      to: phone,
+      template: config.fulfillTemplate,
+    });
+  }
+  return new Response();
+};

--- a/app/routes/webhooks.orders.create.jsx
+++ b/app/routes/webhooks.orders.create.jsx
@@ -1,0 +1,27 @@
+import { authenticate } from "../shopify.server";
+import { getWhatsappConfig } from "../models.whatsapp.server";
+import { sendWhatsappTemplate } from "../whatsapp.server";
+
+export const action = async ({ request }) => {
+  const { payload, shop, topic } = await authenticate.webhook(request);
+  console.log(`Received ${topic} webhook for ${shop}`);
+
+  const config = await getWhatsappConfig(shop);
+  if (!config || !config.status || !config.orderTemplate) {
+    return new Response();
+  }
+  const phone =
+    payload?.customer?.phone ||
+    payload?.shipping_address?.phone ||
+    payload?.billing_address?.phone;
+
+  if (phone) {
+    await sendWhatsappTemplate({
+      phoneNumberId: config.phoneNumberId,
+      accessToken: config.accessToken,
+      to: phone,
+      template: config.orderTemplate,
+    });
+  }
+  return new Response();
+};

--- a/app/whatsapp.server.js
+++ b/app/whatsapp.server.js
@@ -1,0 +1,32 @@
+export async function sendWhatsappTemplate({
+  phoneNumberId,
+  accessToken,
+  to,
+  template,
+  language = "en_US",
+  components = [],
+}) {
+  const url = `https://graph.facebook.com/v19.0/${phoneNumberId}/messages`;
+  const body = {
+    messaging_product: "whatsapp",
+    to,
+    type: "template",
+    template: {
+      name: template,
+      language: { code: language },
+      components,
+    },
+  };
+  const response = await fetch(url, {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${accessToken}`,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify(body),
+  });
+  if (!response.ok) {
+    console.error("WhatsApp API error", await response.text());
+  }
+  return response.json().catch(() => ({}));
+}

--- a/prisma/migrations/20250712115500_add_whatsapp_config/migration.sql
+++ b/prisma/migrations/20250712115500_add_whatsapp_config/migration.sql
@@ -1,0 +1,13 @@
+-- CreateTable
+CREATE TABLE "WhatsappConfig" (
+    "id" INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
+    "shop" TEXT NOT NULL,
+    "accessToken" TEXT NOT NULL,
+    "phoneNumberId" TEXT NOT NULL,
+    "orderTemplate" TEXT,
+    "fulfillTemplate" TEXT,
+    "status" BOOLEAN NOT NULL DEFAULT true
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "WhatsappConfig_shop_key" ON "WhatsappConfig"("shop");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -30,3 +30,13 @@ model Session {
   collaborator  Boolean?  @default(false)
   emailVerified Boolean?  @default(false)
 }
+
+model WhatsappConfig {
+  id             Int     @id @default(autoincrement())
+  shop           String  @unique
+  accessToken    String
+  phoneNumberId  String
+  orderTemplate  String?
+  fulfillTemplate String?
+  status         Boolean @default(true)
+}

--- a/shopify.app.toml
+++ b/shopify.app.toml
@@ -20,9 +20,17 @@ api_version = "2025-07"
   topics = [ "app/scopes_update" ]
   uri = "/webhooks/app/scopes_update"
 
+  [[webhooks.subscriptions]]
+  topics = [ "orders/create" ]
+  uri = "/webhooks/orders/create"
+
+  [[webhooks.subscriptions]]
+  topics = [ "fulfillments/create" ]
+  uri = "/webhooks/fulfillments/create"
+
 [access_scopes]
 # Learn more at https://shopify.dev/docs/apps/tools/cli/configuration#access_scopes
-scopes = "write_products"
+scopes = "write_products,read_orders"
 
 [auth]
 redirect_urls = [ "https://example.com/api/auth" ]


### PR DESCRIPTION
## Summary
- add WhatsApp setup page and DB model
- send order/fulfillment events to WhatsApp Cloud API
- register new webhooks and scopes
- document WhatsApp feature

## Testing
- `npm run lint` *(fails: ESLint couldn't find a config)*

------
https://chatgpt.com/codex/tasks/task_e_68724ba500788321b7062c44772a3cde